### PR TITLE
fix: update category detail page to use slug in news links

### DIFF
--- a/lesson_25/news_project/news_app/context_processor.py
+++ b/lesson_25/news_project/news_app/context_processor.py
@@ -1,8 +1,11 @@
-from .models import News
+from .models import News, Category
 
 def latest_news(request):
     latest_news = News.published.order_by('-published_at')[:10]
+    categories = Category.objects.all()
+
     context = {
-        'latest_news': latest_news
+        'latest_news': latest_news,
+        'categories': categories,
     }
     return context

--- a/lesson_25/news_project/news_app/views.py
+++ b/lesson_25/news_project/news_app/views.py
@@ -151,3 +151,11 @@ class CategoryDetailView(DetailView):
     model = Category
     template_name = "news/category_detail.html"
     context_object_name = "category"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Shu kategoriyaga tegishli yangiliklar
+        context['news_list'] = News.published.filter(category=self.object).order_by('-published_at')
+        # Barcha kategoriyalar (sidebar uchun)
+        context['categories'] = Category.objects.all()
+        return context

--- a/lesson_25/news_project/templates/news/category_detail.html
+++ b/lesson_25/news_project/templates/news/category_detail.html
@@ -13,7 +13,7 @@
           <h2><span>{{ category.name }}</span></h2>
           <div class="single_post_content_left">
             <ul class="business_catgnav wow fadeInDown">
-              {% for news_item in category_news %}
+              {% for news_item in news_list %}
                 {% if forloop.first %}
                   <li>
                     <figure class="bsbig_fig">
@@ -37,7 +37,7 @@
           <!-- Qolgan yangiliklar -->
           <div class="single_post_content_right">
             <ul class="spost_nav">
-              {% for news_item in category_news %}
+              {% for news_item in news_list %}
                 {% if forloop.counter > 1 %}
                   <li>
                     <div class="media wow fadeInDown">


### PR DESCRIPTION
### Changes
- Fixed `category_detail.html` links to use slug instead of id
- Updated `CategoryDetailView` to send `news_list` in context
- Adjusted context processor for categories

### Why
Links from category page were broken because `news_detail` URL expects slug, not id.
