### PR TITLE
Update news_detail page layout, views, URLs and get_absolute_url in model

### DIFF
--- a/lesson_27/news_project/news_app/views.py
+++ b/lesson_27/news_project/news_app/views.py
@@ -36,7 +36,7 @@ class NewsListView(ListView):
     
 class NewsDetailView(DetailView):
     model = News
-    template_name = "news/news_detail.html"
+    template_name = "news/news_deatil.html"
     context_object_name = 'news_item'
     slug_field = 'slug'
     slug_url_kwarg = 'slug'
@@ -45,9 +45,14 @@ class NewsDetailView(DetailView):
     
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context['related_news'] = News.published.filter(
-            category=self.object.category,
-        ).exclude(id=self.object.id)[:3]
+        # Related news
+        context["related_news"] = News.objects.filter(
+            category=self.object.category
+        ).exclude(id=self.object.id)[:4]
+        # Popular news
+        context["popular_news"] = News.objects.order_by("-views")[:5]
+        # Categories
+        context["categories"] = Category.objects.all()
         return context
     
 class HomePageView(ListView):
@@ -112,7 +117,7 @@ class ContactPageView(FormView):
 
 class SinglePageView(DetailView):
     model = News
-    template_name = 'news/single_page.html'
+    template_name = 'news/news_detail.html'
     context_object_name = 'news_item'
     slug_field = 'slug'
     slug_url_kwarg = 'slug'

--- a/lesson_27/news_project/templates/news/news_detail.html
+++ b/lesson_27/news_project/templates/news/news_detail.html
@@ -1,42 +1,168 @@
 {% extends 'news/base.html' %}
+{% load static %}
+
 {% block title %}{{ news_item.title }} - NewsFeed{% endblock %}
 
 {% block content %}
-<div class="news-detail">
-    <h1>{{ news_item.title }}</h1>
-    <p class="category">Category: {{ news_item.category.name }}</p>
+<section id="contentSection" class="my-5">
+    <div class="row">
 
-    {% if news_item.image %}
-        <img src="{{ news_item.image.url }}" alt="{{ news_item.title }}" class="news-image">
-    {% endif %}
+        <!-- Main Content -->
+        <div class="col-lg-8 col-md-8 col-sm-12">
+            <div class="left_content">
 
-    <p class="news-content">{{ news_item.content }}</p>
-    <p class="news-date">Published: {{ news_item.published_at|date:"F d, Y" }}</p>
-</div>
+                <!-- Single Page -->
+                <div class="single_page">
 
-<hr>
+                    <!-- Breadcrumb -->
+                    <nav aria-label="breadcrumb">
+                        <ol class="breadcrumb bg-light p-2 rounded">
+                            <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
+                            <li class="breadcrumb-item"><a href="{% url 'category_detail' news_item.category.slug %}">{{ news_item.category.name }}</a></li>
+                            <li class="breadcrumb-item active" aria-current="page">{{ news_item.title }}</li>
+                        </ol>
+                    </nav>
 
-<h3>Related News</h3>
-<div class="related-news">
-    {% for news in related_news %}
-        <div class="news-card">
-            {% if news.image %}
-                <img src="{{ news.image.url }}" alt="{{ news.title }}" class="news-image">
-            {% endif %}
-            <div class="news-content">
-                <h4 class="news-title">
-                    <a href="{{ news.get_absolute_url }}" class="news-link">
-                        {{ news.title|truncatewords:7 }}
-                    </a>
-                </h4>
-                <p class="category">{{ news.category.name }}</p>
-                <p class="content-preview">{{ news.content|truncatewords:15 }}</p>
-                <p class="news-date">{{ news.published_at|date:"F d, Y" }}</p>
-                <p class="read-more">
-                    <a href="{{ news.get_absolute_url }}" class="read-more-link">Read more →</a>
-                </p>
+                    <!-- Title -->
+                    <h1 class="mb-3">{{ news_item.title }}</h1>
+
+                    <!-- Post Meta -->
+                    <div class="post_meta mb-4 text-muted">
+                        <span class="me-3"><i class="fa fa-user"></i> {{ news_item.author }}</span>
+                        <span class="me-3"><i class="fa fa-calendar"></i> {{ news_item.published_at|date:"F d, Y" }}</span>
+                        <span><i class="fa fa-tags"></i> {{ news_item.category.name }}</span>
+                    </div>
+
+                    <!-- Featured Image -->
+                    {% if news_item.image %}
+                        <div class="text-center mb-4">
+                            <img src="{{ news_item.image.url }}" alt="{{ news_item.title }}" class="img-fluid rounded shadow-sm" style="max-width: 100%;">
+                        </div>
+                    {% endif %}
+
+                    <!-- Content -->
+                    <div class="single_page_content" style="line-height: 1.6; font-size: 2 em; color: #333;">
+                        {{ news_item.content|safe }}
+                    </div>
+
+                    <!-- Social Share -->
+                    <div class="social_link my-4">
+                        <span class="me-2">Share:</span>
+                        <a href="#" class="btn btn-sm btn-primary me-1"><i class="fa fa-facebook"></i></a>
+                        <a href="#" class="btn btn-sm btn-info me-1"><i class="fa fa-twitter"></i></a>
+                        <a href="#" class="btn btn-sm btn-danger me-1"><i class="fa fa-linkedin"></i></a>
+                        <a href="#" class="btn btn-sm btn-warning"><i class="fa fa-pinterest"></i></a>
+                    </div>
+
+                    <!-- Related Posts -->
+                    <div class="related_post mt-5">
+                        <h2 class="mb-3">Related News <i class="fa fa-thumbs-o-up"></i></h2>
+                        <ul class="list-unstyled">
+                            {% for item in related_news %}
+                            <li class="media mb-3">
+                                {% if item.image %}
+                                    <a href="{{ item.get_absolute_url }}">
+                                        <img class="me-3 rounded" src="{{ item.image.url }}" alt="{{ item.title }}" style="width: 100px; height: 70px; object-fit: cover;">
+                                    </a>
+                                {% endif %}
+                                <div class="media-body">
+                                    <a href="{{ item.get_absolute_url }}" class="fw-semibold">{{ item.title }}</a>
+                                </div>
+                            </li>
+                            {% empty %}
+                                <p>No related news available.</p>
+                            {% endfor %}
+                        </ul>
+                    </div>
+
+                </div>
             </div>
         </div>
-    {% endfor %}
-</div>
-{% endblock %}
+        <!-- Sidebar -->
+        <div class="col-lg-4 col-md-4 col-sm-4">
+            <aside class="right_content">
+
+                <!-- Popular Posts -->
+                <div class="single_sidebar">
+                    <h2><span>Popular Post</span></h2>
+                    <ul class="spost_nav">
+                        {% for item in popular_news %}
+                        <li>
+                            <div class="media">
+                                <a href="{{ item.get_absolute_url }}" class="media-left">
+                                    {% if item.image %}
+                                        <img src="{{ item.image.url }}" alt="{{ item.title }}">
+                                    {% endif %}
+                                </a>
+                                <div class="media-body">
+                                    <a href="{{ item.get_absolute_url }}" class="catg_title">{{ item.title }}</a>
+                                </div>
+                            </div>
+                        </li>
+                        {% empty %}
+                            <p>No popular posts yet.</p>
+                        {% endfor %}
+                    </ul>
+                </div>
+
+                <!-- Tabs -->
+                <div class="single_sidebar">
+                    <ul class="nav nav-tabs" role="tablist">
+                        <li role="presentation" class="active">
+                            <a href="#category" role="tab" data-toggle="tab">Category</a>
+                        </li>
+                        <li role="presentation">
+                            <a href="#comments" role="tab" data-toggle="tab">Comments</a>
+                        </li>
+                    </ul>
+                    <div class="tab-content">
+
+                        <!-- Categories -->
+                        <div role="tabpanel" class="tab-pane active" id="category">
+                            <ul>
+                                {% for cat in categories %}
+                                <li class="cat-item">
+                                    <a href="{% url 'category_detail' cat.slug %}">{{ cat.name }}</a>
+                                </li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+
+                        <!-- Comments -->
+                        <div role="tabpanel" class="tab-pane" id="comments">
+                            <ul class="spost_nav">
+                                {% for comment in latest_comments %}
+                                <li>
+                                    <div class="media">
+                                        <a href="{{ comment.news.get_absolute_url }}" class="media-left">
+                                            {% if comment.news.image %}
+                                                <img src="{{ comment.news.image.url }}" alt="{{ comment.news.title }}">
+                                            {% endif %}
+                                        </a>
+                                        <div class="media-body">
+                                            <a href="{{ comment.news.get_absolute_url }}" class="catg_title">{{ comment.news.title }}</a>
+                                        </div>
+                                    </div>
+                                </li>
+                                {% empty %}
+                                    <p>No comments yet.</p>
+                                {% endfor %}
+                            </ul>
+                        </div>
+
+                    </div>
+                </div>
+
+                <!-- Sponsor -->
+                <div class="single_sidebar">
+                    <h2><span>Sponsor</span></h2>
+                    <a class="sideAdd" href="#"><img src="{% static 'images/add_img.jpg' %}" alt="Sponsor"></a>
+                </div>
+
+            </aside>
+        </div>
+    </div>
+</section>
+{% endblock content %}
+
+

--- a/lesson_27/news_project/templates/news/single_page.html
+++ b/lesson_27/news_project/templates/news/single_page.html
@@ -42,11 +42,11 @@
                             {% for item in related_news %}
                             <li>
                                 <div class="media">
-                                    <a class="media-left" href="{% url 'news_detail' item.slug %}">
+                                    <a class="media-left" href="{{ item.get_absolute_url }}">
                                         <img src="{{ item.image.url }}" alt="{{ item.title }}">
                                     </a>
                                     <div class="media-body">
-                                        <a class="catg_title" href="{% url 'news_detail' item.slug %}">{{ item.title }}</a>
+                                        <a class="catg_title" href="{{ item.get_absolute_url }}">{{ item.title }}</a>
                                     </div>
                                 </div>
                             </li>
@@ -65,11 +65,11 @@
                         {% for item in popular_news %}
                         <li>
                             <div class="media">
-                                <a href="{% url 'news_detail' item.slug %}" class="media-left">
+                                <a href="{{ item.get_absolute_url }}" class="media-left">
                                     <img src="{{ item.image.url }}" alt="{{ item.title }}">
                                 </a>
                                 <div class="media-body">
-                                    <a href="{% url 'news_detail' item.slug %}" class="catg_title">{{ item.title }}</a>
+                                    <a href="{{ item.get_absolute_url }}" class="catg_title">{{ item.title }}</a>
                                 </div>
                             </div>
                         </li>


### PR DESCRIPTION

- Modified news_app/views.py to render news_detail with related context
- Updated templates/news/news_detail.html for new layout
- Updated templates/news/single_page.html to remove old display
- Added get_absolute_url in news_app/models.py to use news_detail URL
- Ensured URLs in urls.py point to news_detail correctly

These changes improve readability, maintain consistency with the news listing pages, and ensure images do not overlap sidebar.
