### PR TITLE
Add admin page, staff-only access and news create view updates

### DIFF
--- a/lesson_42/news_project/accounts/urls.py
+++ b/lesson_42/news_project/accounts/urls.py
@@ -83,4 +83,5 @@ urlpatterns = [
     path('profile/', views.dashboard_view, name='user_profile'),
     # path('profile/edit/', views.edit_profile, name='edit_profile'),
     path('profile/edit/', views.EditProfileView.as_view(), name='edit_profile'),
+    path('admin-page/', views.admin_page, name='admin_page'),
 ]

--- a/lesson_42/news_project/accounts/views.py
+++ b/lesson_42/news_project/accounts/views.py
@@ -1,3 +1,4 @@
+from django.contrib.admin.views.decorators import staff_member_required
 from django.shortcuts import render, redirect
 from django.contrib.auth import authenticate, login
 from .forms import LoginForm, UserRegistrationForm, ProfileEditForm, UserEditForm
@@ -8,6 +9,7 @@ from django.views import View
 from .models import Profile
 from django.contrib.auth.views import LoginView
 from news_app.models import News
+from django.contrib.auth.models import User
 
 # Create your views here.
 def user_login(request):
@@ -25,7 +27,7 @@ def user_login(request):
         login(request, user)
         return redirect('news:home')
       else:
-        return render(request, 'accounts/login.html', {
+        return render(request, 'registration/login.html', {
           'form': form,
           'error': "Username yoki parol noto'g'ri!"
         })
@@ -155,3 +157,20 @@ class EditProfileView(LoginRequiredMixin, View):
             'user_form': user_form,
             'profile_form': profile_form
         })
+    
+@staff_member_required  # faqat staff foydalanuvchilar kira oladi
+def admin_page(request):
+    users_count = User.objects.count()
+    news_count = News.objects.count()
+    last_users = User.objects.order_by('-date_joined')[:6]
+    last_news = News.objects.select_related('author').order_by('-created_at')[:6]  # sening News modelida sana maydonini to‘g‘ri yoz
+    admin_users = User.objects.filter(is_staff=True)
+
+    context = {
+        'users_count': users_count,
+        'news_count': news_count,
+        'last_users': last_users,
+        'last_news': last_news,
+        'admin_users': admin_users,
+    }
+    return render(request, 'accounts/admin_page.html', context)

--- a/lesson_42/news_project/news_app/views.py
+++ b/lesson_42/news_project/news_app/views.py
@@ -174,7 +174,7 @@ class CategoryDetailView(DetailView):
         context['categories'] = Category.objects.all()
         return context
     
-class NewsCreateView(LoginRequiredMixin, CreateView):
+class NewsCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
     model = News
     form_class = NewsForm
     template_name = 'crud/news_create.html'
@@ -183,6 +183,9 @@ class NewsCreateView(LoginRequiredMixin, CreateView):
     def form_valid(self, form):
         form.instance.author = self.request.user 
         return super().form_valid(form)
+    
+    def test_func(self):
+        return self.request.user.is_staff or self.request.user.is_superuser
 
 class NewsUpdateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     model = News

--- a/lesson_42/news_project/static/css/style.css
+++ b/lesson_42/news_project/static/css/style.css
@@ -891,3 +891,22 @@ form.form .btn-secondary:hover {
     background: linear-gradient(135deg, #2d3748 0%, #4a5568 100%) !important;
   }
 }
+
+/* admin sahifasi uchun */
+.role-badge {
+  display: inline-block;
+  padding: 5px 12px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: bold;
+  color: #fff;
+}
+
+/* Ranglar */
+.role-badge.super { background-color: #d9534f; }   /* Qizil (danger) */
+.role-badge.admin { background-color: #5bc0de; }   /* Moviy (info) */
+.role-badge.user  { background-color: #777; }      /* Kulrang */
+
+.bottom-space {
+  margin-bottom: 30px; /* xohlagan balandlik */
+}

--- a/lesson_42/news_project/templates/accounts/admin_page.html
+++ b/lesson_42/news_project/templates/accounts/admin_page.html
@@ -1,0 +1,205 @@
+{% extends 'news/base.html' %}
+{% load static %}
+
+{% block title %}Admin Panel{% endblock title %}
+
+{% block content %}
+<div class="container mt-5">
+  <div class="row mb-4">
+    <div class="col-xs-6">
+      <h2>📊 Admin sahifasi</h2>
+    </div>
+    <div class="col-xs-6 text-right">
+      <a href="{% url 'news:news_create' %}" class="btn btn-success">+ Yangilik qo'shish</a>
+    </div>
+  </div>
+
+  <!-- Statistikalar -->
+  <div class="row mb-4">
+    <div class="col-md-6">
+      <div class="card shadow-sm border-primary text-center">
+        <div class="card-body">
+          <h5 class="card-title">👥 Foydalanuvchilar soni</h5>
+          <p class="display-6">{{ users_count }}</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <div class="card shadow-sm border-success text-center">
+        <div class="card-body">
+          <h5 class="card-title">📰 Yangiliklar soni</h5>
+          <p class="display-6">{{ news_count }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- So‘nggi ma'lumotlar -->
+  <div class="row mb-5">
+    <!-- So‘nggi foydalanuvchilar -->
+    <div class="col-md-6 mb-3">
+      <div class="card shadow-sm h-100">
+        <div class="card-header bg-primary text-white">So‘nggi 5 foydalanuvchi</div>
+        <ul class="list-group list-group-flush">
+          {% for user in last_users %}
+          <li class="list-group-item">
+            <strong>{{ user.first_name }} {{ user.last_name }}</strong> 
+            <small class="text-muted">(@{{ user.username }})</small><br>
+            <span class="text-muted">{{ user.email }}</span><br>
+            <small class="text-muted">Qo‘shilgan: {{ user.date_joined|date:"d.m.Y H:i" }}</small><br>
+            <small class="text-muted">Oxirgi login: {{ user.last_login|date:"d.m.Y H:i" }}</small><br>
+
+            <!-- Role -->
+            {% if user.is_superuser %}
+              <span class="badge bg-danger">Superuser</span>
+            {% elif user.is_staff %}
+              <span class="badge bg-info">Admin</span>
+            {% else %}
+              <span class="badge bg-secondary">User</span>
+            {% endif %}
+            
+            <!-- Status -->
+            {% if user.is_active %}
+              <span class="text-success">Active</span>
+            {% else %}
+              <span class="text-danger">Inactive</span>
+            {% endif %}
+          </li>
+          {% empty %}
+          <li class="list-group-item">Hech qanday foydalanuvchi yo‘q</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+
+    <!-- So‘nggi yangiliklar -->
+    <div class="col-md-6 mb-3">
+      <div class="card shadow-sm h-100">
+        <div class="card-header bg-success text-white">So‘nggi 5 yangilik</div>
+        <ul class="list-group list-group-flush">
+          {% for news in last_news %}
+          <li class="list-group-item">
+            <div class="row">
+              {% if news.image %}
+                <div class="col-xs-3">
+                  <img src="{{ news.image.url }}" alt="{{ news.title }}" 
+                      class="img-thumbnail" style="width: 60px; height: 40px; object-fit: cover;">
+                </div>
+              {% endif %}
+              <div class="col-xs-7">
+                <a href="{% url 'news:news_detail' news.slug %}">{{ news.title }}</a>
+                <p class="mb-0 small text-muted">
+                  {{ news.created_at|date:"d.m.Y H:i" }} | by {{ news.author.username }}
+                </p>
+              </div>
+              <div class="col-xs-2 text-right">
+                {% if news.category %}
+                  <span class="badge">{{ news.category.name }}</span>
+                {% endif %}
+              </div>
+            </div>
+          </li>
+          {% empty %}
+          <li class="list-group-item">Hozircha yangiliklar yo‘q</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+    
+    <!-- Adminlar statistikasi -->
+    <div class="row bottom-space">
+      <div class="col-md-6">
+        <div class="panel panel-default text-center">
+          <div class="panel-heading">👑 Adminlar soni</div>
+          <div class="panel-body">
+            <p class="lead">{{ admin_users.count }}</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Adminlar ro'yxati -->
+      <div class="col-md-6">
+        <div class="panel panel-default">
+          <div class="panel-heading bg-dark text-white">👑 Adminlar</div>
+          <ul class="list-group">
+            {% for admin in admin_users %}
+            <li class="list-group-item clearfix">
+              <span>{{ admin.username }}</span>
+              <small class="pull-right text-muted">
+                {% if admin.is_superuser %}Superuser{% else %}Staff{% endif %}
+              </small>
+            </li>
+            {% empty %}
+            <li class="list-group-item">Adminlar mavjud emas</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+
+
+  <!-- Tafsilotlar qismi -->
+  <div class="row">
+    <!-- Foydalanuvchilar tafsilotlari -->
+    <div class="col-md-6">
+      <div class="card shadow-sm">
+        <div class="card-header bg-primary text-white">
+          <h5 class="mb-0">👥 Foydalanuvchilar tafsilotlari</h5>
+        </div>
+        <div class="card-body">
+          <ul class="list-group">
+            {% for user in last_users %}
+              <li class="list-group-item">
+                <div class="row">
+                  <div class="col-xs-9">
+                    <strong>{{ user.first_name }} {{ user.last_name }}</strong>
+                    <small class="text-muted">(@{{ user.username }})</small><br>
+                    <span class="text-muted">{{ user.email }}</span>
+                  </div>
+                  <div class="col-xs-3 text-right">
+                    {% if user.is_superuser %}
+                      <span class="role-badge super">Superuser</span>
+                    {% elif user.is_staff %}
+                      <span class="role-badge admin">Admin</span>
+                    {% else %}
+                      <span class="role-badge user">User</span>
+                    {% endif %}
+                  </div>
+                </div>
+              </li>
+            {% empty %}
+              <li class="list-group-item">Hech qanday foydalanuvchi topilmadi</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- Yangiliklar tafsilotlari -->
+    <div class="col-md-6">
+      <div class="card shadow-sm">
+        <div class="card-header bg-success text-white">
+          <h5 class="mb-0">📰 Yangiliklar tafsilotlari</h5>
+        </div>
+        <div class="card-body">
+          <ul class="list-group">
+            {% for news_item in last_news %}
+              <li class="list-group-item">
+                <strong>{{ news_item.title }}</strong><br>
+                <small class="text-muted">
+                  {{ news_item.created_at|date:"d M Y H:i" }}  
+                  — {{ news_item.author.get_full_name|default:news_item.author.username }}
+                </small>
+              </li>
+            {% empty %}
+              <li class="list-group-item">Hozircha yangilik qo‘shilmagan</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+{% endblock content %}
+

--- a/lesson_42/news_project/templates/news/base.html
+++ b/lesson_42/news_project/templates/news/base.html
@@ -33,6 +33,11 @@
                             <li><a href="{% url 'news:home' %}">Bosh sahifa</a></li>
                             <li><a href="{% url 'news:about' %}">Biz haqimizda</a></li>
                             <li><a href="{% url 'news:contact' %}">Biz bilan aloqa</a></li>
+                            {% if user.is_staff %}
+                            <li class="nav-item">
+                                <a class="nav-link" href="{% url 'accounts:admin_page' %}">Admin</a>
+                            </li>
+                            {% endif %}
                         </ul>
                     </div>
                     <!-- base.html da header_top_right qismini yangilash -->

--- a/lesson_42/news_project/templates/registration/login.html
+++ b/lesson_42/news_project/templates/registration/login.html
@@ -16,8 +16,12 @@
     </form>
   </div>
   <div class="text-center mt-3">
-    <a href="{% url 'accounts:password_reset' %}" class="text-decoration-none text-primary">
+    <a href="{% url 'accounts:password_reset' %}" class="text-decoration-none text-primary me-3">
         Parolni unutdingizmi?
     </a>
-</div>
+      <span class="mx-2">|</span>
+    <a href="{% url 'accounts:register' %}" class="text-decoration-none text-primary">
+        Ro'yxatdan o'tish
+    </a>
+  </div>
 {% endblock content %}


### PR DESCRIPTION
### Features included:

- [x] **Admin Page** (`/admin-page/`)
  - Displays user and news statistics
  - Lists latest users and news
  - Shows admin users list
  - Accessible only to staff and superuser (@staff_member_required)

- [x] **NewsCreateView** update (`news_app/views.py`)
  - Only staff/superuser can create news (test_func)
  - Automatically sets the author (form_valid)

- [x] **Navbar update** (`templates/news/base.html`)
  - Adds "Admin" link visible only to staff users

- [x] **Login page update** (`templates/registration/login.html`)
  - Added "Forgot password?" and "Register" links

- [x] **New template**: `templates/accounts/admin_page.html` created

- [x] **Routing update** (`accounts/urls.py`)
  - Added `/admin-page/` path

### Notes:
- Uses Bootstrap 3, layout spacing (margin/padding) applied for proper appearance
- Admin page accessible only to staff or superuser users
