### PR TITLE
Add cleanup script for merged branches

### DIFF
--- a/cleanup-merged-branches.ps1
+++ b/cleanup-merged-branches.ps1
@@ -1,0 +1,42 @@
+# cleanup-merged-branches.ps1
+# Main branchga merge bo'lgan local va remote branchlarni avtomatik o'chirish
+
+Write-Host "➡️  Main branchga o'tilmoqda..."
+git checkout main
+
+Write-Host "➡️  Local branchlarni yangilash..."
+git fetch --all --prune
+
+# Variant tanlash
+Write-Host "`nQaysi tozalash turini xohlaysiz?"
+Write-Host "1 - Faqat LOCAL branchlarni o'chirish"
+Write-Host "2 - Faqat REMOTE branchlarni o'chirish"
+Write-Host "3 - Ikkalasini ham (default)"
+$choice = Read-Host "Tanlang (1/2/3)"
+
+if ([string]::IsNullOrWhiteSpace($choice)) { $choice = "3" }
+
+# Local branchlarni o‘chirish
+if ($choice -eq "1" -or $choice -eq "3") {
+    Write-Host "➡️  Merge qilingan local branchlarni topish..."
+    $mergedBranches = git branch --merged main | ForEach-Object { $_.Trim() } | Where-Object { ($_ -ne "main") -and ($_ -ne "* main") }
+
+    foreach ($branch in $mergedBranches) {
+        Write-Host "   ❌ Local branch o'chirilyapti: $branch"
+        git branch -d $branch
+    }
+}
+
+# Remote branchlarni o‘chirish
+if ($choice -eq "2" -or $choice -eq "3") {
+    Write-Host "➡️  Merge qilingan remote branchlarni topish..."
+    $remoteMerged = git branch -r --merged origin/main | ForEach-Object { $_.Trim() } | Where-Object { ($_ -notmatch "origin/main") -and ($_ -notmatch "HEAD") }
+
+    foreach ($branch in $remoteMerged) {
+        $cleanName = $branch -replace "origin/", ""
+        Write-Host "   ❌ Remote branch o'chirilyapti: $cleanName"
+        git push origin --delete $cleanName
+    }
+}
+
+Write-Host "✅ Tozalash tugadi! Endi faqat main va merge qilinmagan branchlar qoldi."


### PR DESCRIPTION
This PR introduces a PowerShell helper script `cleanup-merged-branches.ps1` to automatically clean up branches that have been merged into the main branch. 

Features:
- Deletes merged **local branches**.
- Deletes merged **remote branches** on GitHub.
- Optionally allows the user to choose whether to clean local, remote, or both types of branches.
- Ensures that the main branch and unmerged branches remain untouched.

This script helps keep the repository clean, organized, and prevents clutter from old merged branches. 

Usage:
1. Navigate to the repository folder in PowerShell.
2. Run the script: .\cleanup-merged-branches.ps1
3. Follow the on-screen options to select which branches to clean.
