### PR TITLE
feat(news): display comment count in news detail page

### DIFF
--- a/lesson_46/news_project/templates/news/news_detail.html
+++ b/lesson_46/news_project/templates/news/news_detail.html
@@ -33,13 +33,16 @@
                     <h1 class="mb-3">{{ news_item.title }}</h1>
 
                     <!-- Post Meta -->
-                    <div class="post_meta mb-4 text-muted">
+                    <div class="post_meta mb-4 text-muted" style="display: flex; gap: 10px; flex-wrap: wrap; align-items: center;">
                         <span class="me-3"><i class="fa fa-user"></i> {{ news_item.author }}</span>
                         <span class="me-3"><i class="fa fa-calendar"></i> {{ news_item.published_at|date:"F d, Y" }}</span>
                         <span><i class="fa fa-tags"></i> {{ news_item.category.name }}</span>
                         <span class="views-count">
                             <i class="fa-solid fa-eye"></i>
                             {{ news_item.views }}
+                        </span>
+                        <span class="comment-count">
+                            <i class="fa-solid fa-comment"></i> {{ comments.count }}
                         </span>
                     </div>
 


### PR DESCRIPTION
### Summary
Added comment count display to the news detail page.

### Changes
- Updated `news_detail.html` to show the number of comments.
- Added comment icon next to comment count.

### Impact
Improves user experience by making engagement metrics visible.
